### PR TITLE
Upgrade `isort` to fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,5 +139,3 @@ level in the confidence interval computation.
 ## 0.1.0 - 2021-02-04
 
 Initial release
-
-

--- a/pykelihood/distributions.py
+++ b/pykelihood/distributions.py
@@ -108,7 +108,7 @@ class Distribution(Parametrized):
         def to_minimize(x) -> float:
             return score(init.with_params(x), data)
 
-        res = minimize(to_minimize, x0, method="Nelder-Mead", options={'maxiter': 1500})
+        res = minimize(to_minimize, x0, method="Nelder-Mead", options={"maxiter": 1500})
         return init.with_params(res.x)
 
     def _process_fit_params(self, **kwds):

--- a/pykelihood/profiler.py
+++ b/pykelihood/profiler.py
@@ -110,7 +110,9 @@ class Profiler(object):
         value_threshold = func - chi2.ppf(self.inference_confidence, df=1) / 2
 
         def is_inside_conf_interval(x: float):
-            new_opt = opt.fit_instance(self.data, score=self.score_function, **{param: x})
+            new_opt = opt.fit_instance(
+                self.data, score=self.score_function, **{param: x}
+            )
             return -self.score_function(new_opt, self.data) >= value_threshold
 
         def is_outside_conf_interval(x: float):
@@ -149,8 +151,20 @@ class Profiler(object):
 
         mapping = np.linspace(lb, ub, num=int(1 / precision))
         search_size = int(step / ((ub - lb) * precision))
-        lb_index = bisect.bisect_left(LazyMappingList(mapping, is_inside_conf_interval), True, lo=0, hi=search_size)
-        ub_index = bisect.bisect_left(LazyMappingList(mapping, is_outside_conf_interval), True, lo=len(mapping) - search_size) - 1
+        lb_index = bisect.bisect_left(
+            LazyMappingList(mapping, is_inside_conf_interval),
+            True,
+            lo=0,
+            hi=search_size,
+        )
+        ub_index = (
+            bisect.bisect_left(
+                LazyMappingList(mapping, is_outside_conf_interval),
+                True,
+                lo=len(mapping) - search_size,
+            )
+            - 1
+        )
 
         return mapping[lb_index], mapping[ub_index]
 


### PR DESCRIPTION
`isort<1.11.5` installation from source was broken by newer versions of `poetry-core`, so the pre-commit hooks could not run anymore.

See https://github.com/PyCQA/isort/issues/2077.