### PR TITLE
Make fit an instance method and deprecate fit_instance

### DIFF
--- a/docs/source/modules/distributions.rst
+++ b/docs/source/modules/distributions.rst
@@ -23,7 +23,6 @@ some parameters have been adjusted (e.g., the GEV distribution) to align with st
 
    ~Distribution.cdf
    ~Distribution.fit
-   ~Distribution.fit_instance
    ~Distribution.inverse_cdf
    ~Distribution.isf
    ~Distribution.logcdf

--- a/pykelihood/distributions/custom.py
+++ b/pykelihood/distributions/custom.py
@@ -425,7 +425,7 @@ class TruncatedDistribution(Distribution):
         """
         return x[self._valid_indices(x)]
 
-    def fit_instance(self, *args, **kwargs):
+    def fit(self, *args, **kwargs):
         """
         Fit the instance to the data.
 
@@ -442,7 +442,7 @@ class TruncatedDistribution(Distribution):
             The fitted instance.
         """
         kwargs.update(lower_bound=self.lower_bound, upper_bound=self.upper_bound)
-        return super().fit_instance(*args, **kwargs)
+        return super().fit(*args, **kwargs)
 
     def rvs(self, size: int, *args, **kwargs):
         """

--- a/pykelihood/parameters.py
+++ b/pykelihood/parameters.py
@@ -166,14 +166,13 @@ class Parametrized:
         return results
 
     @property
-    def optimisation_params(self) -> tuple[Parametrized]:
+    def optimisation_params(self) -> tuple[Parameter, ...]:
         """
         Get all parameters used in the optimization.
 
         Returns
         -------
-        Tuple[Parametrized]
-            The optimization parameters.
+        The optimization parameters.
         """
         unique = []
         for q in (p_ for p in self.params for p_ in p.optimisation_params):
@@ -182,13 +181,13 @@ class Parametrized:
         return unique
 
     @property
-    def optimisation_param_dict(self) -> dict[str, Parametrized]:
+    def optimisation_param_dict(self) -> dict[str, Parameter]:
         """
         Get a dictionary of optimization parameter names and their values.
 
         Returns
         -------
-        Dict[str, Parametrized]
+        Dict[str, Parameter]
             The optimization parameter dictionary.
         """
         p_dict = flatten_dict(self._optimisation_param_dict_helper())

--- a/pykelihood/profiler.py
+++ b/pykelihood/profiler.py
@@ -86,7 +86,7 @@ class Profiler:
         tuple
             A tuple containing the estimate and the score function value.
         """
-        estimate = self.distribution.fit_instance(
+        estimate = self.distribution.fit(
             self.data,
             score=self.score_function,
             x0=self.x0,
@@ -148,11 +148,7 @@ class Profiler:
         profile_ll = []
         params = []
         for x in range_for_param:
-            pl = opt.fit_instance(
-                self.data,
-                score=self.score_function,
-                **{param: x},
-            )
+            pl = opt.fit(self.data, score=self.score_function, **{param: x})
             pl_value = -self.score_function(pl, self.data)
             pl_value = pl_value if isinstance(pl_value, float) else pl_value[0]
             if np.isfinite(pl_value):
@@ -190,9 +186,7 @@ class Profiler:
         value_threshold = func - chi2.ppf(self.inference_confidence, df=1) / 2
 
         def score(x: float):
-            new_opt = opt.fit_instance(
-                self.data, score=self.score_function, **{param: x}
-            )
+            new_opt = opt.fit(self.data, score=self.score_function, **{param: x})
             return -self.score_function(new_opt, self.data)
 
         def delta_to_threshold(x: float):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,3 @@ extend-select = [
     "I", # Import sorting
     "UP",  # PyUpgrade
 ]
-
-[tool.pytest.ini_options]
-durations = 10
-verbose = true

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -35,7 +35,7 @@ def normal_data():
 
 def test_log_likelihood_is_correct(normal_data):
     ndata = normal_data[:1000]
-    n = Normal(loc=kernels.linear(np.arange(len(ndata)))).fit_instance(ndata)
+    n = Normal(loc=kernels.linear(np.arange(len(ndata)))).fit(ndata)
     actual = log_likelihood(n, ndata)
     expected = sum(
         norm.logpdf(x, loc=loc, scale=n.scale()) for x, loc in zip(ndata, n.loc())

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -9,25 +9,25 @@ from pykelihood.profiler import Profiler
 
 @pytest.fixture(scope="module")
 def profiler(dataset):
-    fit = GEV.fit(dataset)
+    fit = GEV().fit(dataset)
     return Profiler(fit, dataset)
 
 
 @pytest.fixture(scope="module")
 def profiler_with_single_profiling_param(dataset):
-    fit = GEV.fit(dataset)
+    fit = GEV().fit(dataset)
     return Profiler(fit, dataset, single_profiling_param="shape")
 
 
 @pytest.fixture(scope="module")
 def profiler_with_fixed_param(dataset):
-    fit = GEV.fit(dataset, scale=1.0)
+    fit = GEV().fit(dataset, scale=1.0)
     return Profiler(fit, dataset)
 
 
 @pytest.fixture(scope="module")
 def profiler_with_trend(dataset):
-    fit = GEV.fit(
+    fit = GEV().fit(
         dataset, loc=kernels.linear(np.linspace(1, len(dataset), len(dataset)))
     )
     return Profiler(fit, dataset)


### PR DESCRIPTION
Having `fit` be a class method has been troublesome to generate distributions and parameters with a varying number of parameters, so let's remove this basic use-case. `fit` now behaves like `fit_instance` did, and replaces it.