### PR TITLE
Use uv to install dependencies in docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,13 +1,19 @@
+# Example configuration at: https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
+  jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs
 
 sphinx:
   configuration: docs/source/conf.py
-
-python:
-  install:
-    - requirements: requirements-docs.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,0 @@
-sphinx==5.0
-pydata-sphinx-theme==0.13.3
-.


### PR DESCRIPTION
Hopefully it will make the workflow faster since the doc build is now slower than the test suite. We can also drop the duplicate docs requirements file.