### PR TITLE
Introduce effects as generalized kernels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ tool for statistical modeling.
 -------------
 Documentation
 -------------
-For detailed documentation, please visit the `official documentation <https://pykelihood.readthedocs.io>`_.
+For detailed documentation, please visit the `official documentation <https://pykelihood.readthedocs.io/en/latest/>`_.
 
 
 Installation

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -2,10 +2,11 @@ Modules
 =======
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 2
 
-   modules/distributions
-   modules/parameters
-   modules/kernels
-   modules/metrics
-   modules/profiler
+    modules/distributions
+    modules/parameters
+    modules/effects
+    modules/kernels
+    modules/metrics
+    modules/profiler

--- a/docs/source/modules/effects.rst
+++ b/docs/source/modules/effects.rst
@@ -1,0 +1,41 @@
+Effects
+=======
+
+The :mod:`pykelihood.effects` module provides the building blocks for covariate-dependent
+models. Effects can be composed using arithmetic operators and used directly as
+distribution parameters.
+
+.. code-block:: python
+
+    import numpy as np
+    from pykelihood.effects import linear
+
+    x = np.linspace(0.0, 1.0, 5)
+    trend = linear(slope=2.0).with_covariate(x)
+
+    trend.eval({})
+
+.. currentmodule:: pykelihood.effects
+
+.. rubric:: Classes
+
+.. autosummary::
+   :toctree: generated/
+
+   ~Effect
+   ~FunctionEffect
+   ~BoundEffect
+
+.. rubric:: Functions
+
+.. autosummary::
+   :toctree: generated/
+
+   ~build_effect
+   ~define_effect
+   ~constant
+   ~linear
+   ~polynomial
+   ~categorical
+   ~gaussian
+   ~exp

--- a/docs/source/modules/kernels.rst
+++ b/docs/source/modules/kernels.rst
@@ -1,10 +1,30 @@
 Kernels
-==========
+=======
+
+.. warning::
+
+   For new code, prefer using :mod:`pykelihood.effects` directly. The kernel functions here
+   are thin wrappers maintained for backward compatibility.
 
 Kernels are used to define trends in distribution parameters with regards to specific covariates.
 They can be as complex as necessary but we provide by default a set of common kernels that can be
 used directly or as a base for more complex ones.
 
+.. code-block:: python
+
+    import numpy as np
+    from pykelihood import kernels
+    from pykelihood.distributions import Normal
+
+    x = np.linspace(0.0, 1.0, 100)
+    loc = kernels.linear(x, a=1.0, b=2.0)
+    scale = kernels.constant(0.5)
+
+    model = Normal(loc=loc, scale=scale)
+    sample = model.rvs(10)
+
+The same module also covers polynomial, trigonometric, regression-style, and
+categorical helpers.
 
 .. currentmodule:: pykelihood.kernels
 
@@ -14,24 +34,18 @@ used directly or as a base for more complex ones.
    :toctree: generated/
 
    ~Kernel
-   ~constant
-
-.. rubric:: Methods
-
-.. autosummary::
-   :toctree: generated/
-
-   ~Kernel.with_covariate
 
 .. rubric:: Functions
 
 .. autosummary::
    :toctree: generated/
 
+   ~constant
    ~linear
    ~polynomial
    ~exponential
    ~exponential_ratio
+   ~gaussian
    ~trigonometric
    ~linear_regression
    ~exponential_linear_regression

--- a/docs/source/modules/parameters.rst
+++ b/docs/source/modules/parameters.rst
@@ -4,7 +4,7 @@ Parameters
 The parameters module provides a framework for defining and managing parameters
 used in statistical models and distributions. It allows for the creation of parameter objects
 that can be optimized, ensuring that they are properly initialized.
-Parameters can take any form, including constants or kernels.
+Parameters can take any form, including constants or effect expressions.
 
 .. currentmodule:: pykelihood.parameters
 

--- a/pykelihood/effects.py
+++ b/pykelihood/effects.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import abc
+import inspect
+import operator
+from collections.abc import Callable, Collection, Hashable, Iterator, Mapping, Sequence
+from functools import wraps
+from typing import Any, Generic, TypeVar
+
+import numpy as np
+import numpy.typing as npt
+from typing_extensions import Self
+
+from pykelihood.expr import Expr, Node, PathElem, ensure_node, require_expr
+from pykelihood.parameters import Parameter
+
+TEffect = TypeVar("TEffect", bound="Effect")
+
+
+def _coerce_effect_arg(value: Any) -> Effect | Expr:
+    """Normalize a helper argument to something the effect graph can store."""
+    if isinstance(value, Effect):
+        return value
+    return require_expr(ensure_node(value))
+
+
+def _evaluate_effect_arg(
+    node: Effect | Expr,
+    covariate: npt.ArrayLike,
+    state: Mapping[Parameter, npt.NDArray[np.float64]],
+) -> npt.NDArray[np.float64]:
+    """Resolve an effect/expression child to concrete numeric values."""
+    if isinstance(node, Effect):
+        return node.eval(covariate, state)
+    return node.eval(state)
+
+
+class Effect(Node, abc.ABC):
+    """Base class for covariate-dependent symbolic effects."""
+
+    @abc.abstractmethod
+    def eval(
+        self,
+        covariate: npt.ArrayLike,
+        state: Mapping[Parameter, npt.NDArray[np.float64]],
+    ) -> npt.NDArray[np.float64]:
+        raise NotImplementedError
+
+    def with_covariate(self, covariate: npt.ArrayLike) -> BoundEffect[Self]:
+        """Bind a concrete covariate while leaving the parameter state explicit."""
+        return BoundEffect(self, covariate)
+
+    def __add__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.add(left, right),
+            {"left": _coerce_effect_arg(self), "right": _coerce_effect_arg(other)},
+            "+",
+        )
+
+    def __radd__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.add(left, right),
+            {"left": _coerce_effect_arg(other), "right": _coerce_effect_arg(self)},
+            "+",
+        )
+
+    def __sub__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.sub(left, right),
+            {"left": _coerce_effect_arg(self), "right": _coerce_effect_arg(other)},
+            "-",
+        )
+
+    def __rsub__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.sub(left, right),
+            {"left": _coerce_effect_arg(other), "right": _coerce_effect_arg(self)},
+            "-",
+        )
+
+    def __mul__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.mul(left, right),
+            {"left": _coerce_effect_arg(self), "right": _coerce_effect_arg(other)},
+            "*",
+        )
+
+    def __rmul__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.mul(left, right),
+            {"left": _coerce_effect_arg(other), "right": _coerce_effect_arg(self)},
+            "*",
+        )
+
+    def __truediv__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.truediv(left, right),
+            {"left": _coerce_effect_arg(self), "right": _coerce_effect_arg(other)},
+            "/",
+        )
+
+    def __rtruediv__(self, other: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.truediv(left, right),
+            {"left": _coerce_effect_arg(other), "right": _coerce_effect_arg(self)},
+            "/",
+        )
+
+    def __pow__(self, power: Any) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, left, right: operator.pow(left, right),
+            {"left": _coerce_effect_arg(self), "right": _coerce_effect_arg(power)},
+            "**",
+        )
+
+    def __neg__(self) -> FunctionEffect:
+        return FunctionEffect(
+            lambda _x, arg: operator.neg(arg),
+            {"operand": _coerce_effect_arg(self)},
+            "-",
+        )
+
+
+class FunctionEffect(Effect):
+    """Effect backed by a Python callable and a mapping of symbolic arguments."""
+
+    def __init__(
+        self,
+        function: Callable[..., Any],
+        args: Mapping[PathElem, Effect | Expr],
+        name: str,
+    ) -> None:
+        self.function = function
+        self.args = dict(args)
+        self.name = name
+
+    def iter_children(self) -> Iterator[tuple[PathElem, Node]]:
+        yield from self.args.items()
+
+    def eval(
+        self,
+        covariate: npt.ArrayLike,
+        state: Mapping[Parameter, npt.NDArray[np.float64]],
+    ) -> npt.NDArray[np.float64]:
+        values = [
+            _evaluate_effect_arg(arg, covariate, state) for arg in self.args.values()
+        ]
+        return np.asarray(self.function(covariate, *values), dtype=np.float64)
+
+
+def build_effect(
+    function: Callable[..., Any],
+    *,
+    name: str,
+    parameter_names: Sequence[PathElem],
+    arguments: Mapping[PathElem, Effect | Expr | npt.ArrayLike] | None = None,
+) -> FunctionEffect:
+    """Build an effect from a callable and an explicit named argument mapping.
+
+    ``arguments`` supplies the resolved node or literal value for each named callable
+    parameter. Omitted names become free ``Parameter`` objects with ``init=0.0``.
+
+    Helper constructors that want different defaults should create explicit
+    ``Parameter(init=...)`` objects and pass them in ``arguments``.
+    """
+    resolved_arguments = {} if arguments is None else dict(arguments)
+    final_parameters: dict[PathElem, Effect | Expr] = {}
+
+    for parameter_name in parameter_names:
+        if parameter_name in resolved_arguments:
+            final_parameters[parameter_name] = _coerce_effect_arg(
+                resolved_arguments[parameter_name]
+            )
+            continue
+
+        if isinstance(parameter_name, str):
+            final_parameters[parameter_name] = Parameter(init=0.0, name=parameter_name)
+        else:
+            final_parameters[parameter_name] = Parameter(init=0.0)
+
+    return FunctionEffect(function, final_parameters, name)
+
+
+class BoundEffect(Expr, Generic[TEffect]):
+    """Effect with a fixed covariate and an explicit state-dependent evaluation."""
+
+    def __init__(self, effect: TEffect, covariate: npt.ArrayLike) -> None:
+        self.effect = effect
+        self.covariate = covariate
+
+    def iter_children(self):
+        return self.effect.iter_children()
+
+    def with_covariate(self, covariate: npt.ArrayLike) -> Self:
+        return type(self)(self.effect, covariate)
+
+    def eval(
+        self, state: Mapping[Parameter, npt.NDArray[np.float64]]
+    ) -> npt.NDArray[np.float64]:
+        return self.effect.eval(self.covariate, state)
+
+
+def define_effect(function: Callable[..., Any]) -> Callable[..., FunctionEffect]:
+    """Wrap a simple effect implementation as a `FunctionEffect` builder.
+
+    The decorated function should have signature ``(x, ...)`` where ``x`` is the
+    covariate and the remaining parameters describe the effect arguments. Default
+    values on those parameters are interpreted as initial values for free
+    `Parameter`s created when the caller omits that argument.
+
+    Callers of the decorated helper may pass literals, `Expr`s, or `Effect`s for
+    those arguments. The decorated function itself does not receive those symbolic
+    objects: at evaluation time it is called with the covariate and the resolved
+    numeric array values of each argument.
+
+    Example:
+        @define_effect
+        def linear(x: npt.ArrayLike, slope: npt.ArrayLike = 0.0) -> npt.NDArray[np.float64]:
+            return np.asarray(slope, dtype=np.float64) * np.asarray(x, dtype=np.float64)
+
+        effect1 = linear()  # slope is a free Parameter with init=0.0
+        effect2 = linear(slope=2.0)  # slope is fixed at 2.0
+        effect3 = linear(slope=Parameter(init=3.0))  # slope is a free Parameter with init=3.0
+    """
+    signature = inspect.signature(function)
+    parameters = tuple(signature.parameters.values())
+    if not parameters:
+        raise TypeError("define_effect expects a function with a covariate parameter.")
+    effect_parameters = parameters[1:]
+    effect_signature = inspect.Signature(parameters=effect_parameters)
+    parameter_names = tuple(parameter.name for parameter in effect_parameters)
+    default_inits = {
+        parameter.name: parameter.default
+        for parameter in effect_parameters
+        if parameter.default is not inspect.Parameter.empty
+    }
+
+    @wraps(function)
+    def build(*args: Any, **kwargs: Any) -> FunctionEffect:
+        bound = effect_signature.bind_partial(*args, **kwargs)
+        arguments: dict[PathElem, Effect | Expr | npt.ArrayLike] = {
+            name: value for name, value in bound.arguments.items()
+        }
+        for name, value in default_inits.items():
+            if name not in arguments:
+                arguments[name] = Parameter(init=value, name=name)
+        return build_effect(
+            function,
+            name=function.__name__,
+            parameter_names=parameter_names,
+            arguments=arguments,
+        )
+
+    return build
+
+
+@define_effect
+def constant(x: npt.ArrayLike, value: npt.ArrayLike = 0.0) -> npt.NDArray[np.float64]:
+    return np.zeros_like(x, dtype=np.float64) + np.asarray(value, dtype=np.float64)
+
+
+@define_effect
+def linear(x: npt.ArrayLike, slope: npt.ArrayLike = 0.0) -> npt.NDArray[np.float64]:
+    x_value = np.asarray(x, dtype=np.float64)
+    return np.asarray(slope, dtype=np.float64) * x_value
+
+
+@define_effect
+def gaussian(
+    x: npt.ArrayLike,
+    mu: npt.ArrayLike = 0.0,
+    sigma: npt.ArrayLike = 1.0,
+    scaling: npt.ArrayLike = 1.0,
+) -> npt.NDArray[np.float64]:
+    """Return a gaussian-shaped effect over the covariate."""
+    x_value = np.asarray(x, dtype=np.float64)
+    mu_value = np.asarray(mu, dtype=np.float64)
+    sigma_value = np.asarray(sigma, dtype=np.float64)
+    scaling_value = np.asarray(scaling, dtype=np.float64)
+    mult = scaling_value * 1.0 / (sigma_value * np.sqrt(2.0 * np.pi))
+    expo = np.exp(-((x_value - mu_value) ** 2) / sigma_value**2)
+    return mult * expo
+
+
+def polynomial(
+    *,
+    degree: int,
+    init: Mapping[int, npt.ArrayLike] | None = None,
+    _coefficients: Mapping[int, Effect | Expr | npt.ArrayLike] | None = None,
+) -> FunctionEffect:
+    """Build a polynomial effect."""
+    if degree < 0:
+        raise ValueError("degree must be non-negative.")
+
+    parameter_names = tuple(range(degree + 1))
+    named_init = {} if init is None else dict(init)
+    named_coefficients = {} if _coefficients is None else dict(_coefficients)
+
+    def polynomial_fn(
+        x: npt.ArrayLike, *resolved: npt.ArrayLike
+    ) -> npt.NDArray[np.float64]:
+        x_value = np.asarray(x, dtype=np.float64)
+        broadcasted = np.broadcast_arrays(
+            *[np.asarray(value, dtype=np.float64) for value in resolved]
+        )
+        coeffs = np.stack(broadcasted)
+        return np.asarray(
+            np.polynomial.polynomial.polyval(x_value, coeffs), dtype=np.float64
+        )
+
+    return build_effect(
+        polynomial_fn,
+        name="polynomial",
+        parameter_names=parameter_names,
+        arguments={
+            **{name: Parameter(init=value) for name, value in named_init.items()},
+            **named_coefficients,
+        },
+    )
+
+
+class CategoricalEffect(Effect):
+    """Effect that maps categorical covariate values to per-level expressions."""
+
+    def __init__(
+        self, levels: Sequence[Hashable], level_args: Mapping[Hashable, Effect | Expr]
+    ) -> None:
+        self.levels = tuple(levels)
+        self.level_args = dict(level_args)
+
+    def iter_children(self) -> Iterator[tuple[PathElem, Node]]:
+        for index, level in enumerate(self.levels):
+            yield index, self.level_args[level]
+
+    def eval(
+        self,
+        covariate: npt.ArrayLike,
+        state: Mapping[Parameter, npt.NDArray[np.float64]],
+    ) -> npt.NDArray[np.float64]:
+        values = np.asarray(covariate, dtype=object)
+        mapping = {
+            level: _evaluate_effect_arg(arg, covariate, state)
+            for level, arg in self.level_args.items()
+        }
+        flattened = [mapping[value] for value in values.reshape(-1)]
+        return np.asarray(flattened, dtype=np.float64).reshape(values.shape)
+
+
+def categorical(
+    *,
+    levels: Collection[Hashable],
+    fixed_values: Mapping[Any, Effect | Expr | npt.ArrayLike] | None = None,
+) -> CategoricalEffect:
+    """Build a categorical effect indexed by the original level values."""
+    ordered_levels = tuple(dict.fromkeys(levels))
+    if len(ordered_levels) != len(tuple(levels)):
+        raise ValueError("categorical levels must be unique.")
+    fixed_values_by_level = {} if fixed_values is None else dict(fixed_values)
+    level_args: dict[Hashable, Effect | Expr] = {}
+    for level in ordered_levels:
+        if level in fixed_values_by_level:
+            level_args[level] = _coerce_effect_arg(fixed_values_by_level[level])
+        else:
+            level_args[level] = Parameter(init=0.0)
+    return CategoricalEffect(ordered_levels, level_args)
+
+
+def exp(value: Effect | Expr | npt.ArrayLike) -> FunctionEffect:
+    """Exponentiate another effect or expression."""
+    return FunctionEffect(
+        lambda _x, arg: np.exp(arg), {"arg": _coerce_effect_arg(value)}, "exp"
+    )
+
+
+def sum(
+    value: Effect | Expr | npt.ArrayLike, *, axis: int | None = None
+) -> FunctionEffect:
+    """Reduce an effect or expression with `np.sum`."""
+    return FunctionEffect(
+        lambda _x, arg: np.sum(arg, axis=axis),
+        {"arg": _coerce_effect_arg(value)},
+        "sum",
+    )

--- a/pykelihood/expr.py
+++ b/pykelihood/expr.py
@@ -2,31 +2,41 @@ from __future__ import annotations
 
 import abc
 import operator
-from collections.abc import Iterator
-from typing import Any, Union
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union, overload
 
 import numpy as np
 import numpy.typing as npt
 
+if TYPE_CHECKING:
+    from pykelihood.parameters import Parameter
+
 PathElem = Union[str, int]
 NodePath = tuple[PathElem, ...]
+TNode = TypeVar("TNode", bound="Node")
 
 
+@overload
+def ensure_node(value: TNode) -> TNode: ...
+@overload
+def ensure_node(value: npt.ArrayLike) -> Constant: ...
 def ensure_node(value: Node | npt.ArrayLike) -> Node:
     if isinstance(value, Node):
         return value
     return Constant(value)
 
 
-class Node(abc.ABC):
+def require_expr(node: Node) -> Expr:
+    if not isinstance(node, Expr):
+        raise TypeError("Expected an Expr.")
+    return node
+
+
+class Node:
     """Base class for graph nodes."""
 
     def iter_children(self) -> Iterator[tuple[PathElem, Node]]:
         return iter(())
-
-    @abc.abstractmethod
-    def __call__(self):
-        raise NotImplementedError
 
     def __add__(self, other: Any) -> FunctionExpr:
         return FunctionExpr(
@@ -77,20 +87,32 @@ class Node(abc.ABC):
         return FunctionExpr(operator.neg, (self,), "-", ("operand",))
 
 
-class Constant(Node):
+class Expr(Node, abc.ABC):
+    """Base class for deterministic evaluable nodes."""
+
+    @abc.abstractmethod
+    def eval(
+        self, state: Mapping[Parameter, npt.NDArray[np.float64]]
+    ) -> npt.NDArray[np.float64]:
+        raise NotImplementedError
+
+
+class Constant(Expr):
     """Literal value normalized into a graph node."""
 
     def __init__(self, value: npt.ArrayLike):
         self.value = np.asarray(value, dtype=np.float64)
 
-    def __call__(self) -> npt.NDArray[np.float64]:
+    def eval(
+        self, state: Mapping[Parameter, npt.NDArray[np.float64]]
+    ) -> npt.NDArray[np.float64]:
         return self.value
 
     def __repr__(self) -> str:
         return f"Constant({self.value!r})"
 
 
-class FunctionExpr(Node):
+class FunctionExpr(Expr):
     """Arithmetic expression node built from other nodes."""
 
     def __init__(
@@ -101,7 +123,7 @@ class FunctionExpr(Node):
         arg_names: tuple[PathElem, ...] | None = None,
     ) -> None:
         self.function = function
-        self.args = args
+        self.args = tuple(require_expr(arg) for arg in args)
         self.name = name
         self.arg_names = arg_names
 
@@ -110,8 +132,10 @@ class FunctionExpr(Node):
             child_name = index if self.arg_names is None else self.arg_names[index]
             yield child_name, arg
 
-    def __call__(self):
-        return self.function(*(arg() for arg in self.args))
+    def eval(
+        self, state: Mapping[Parameter, npt.NDArray[np.float64]]
+    ) -> npt.NDArray[np.float64]:
+        return self.function(*(arg.eval(state) for arg in self.args))
 
     def __repr__(self) -> str:
         return f"FunctionExpr({self.name!r}, args={self.args!r})"

--- a/pykelihood/kernels.py
+++ b/pykelihood/kernels.py
@@ -1,58 +1,177 @@
+from __future__ import annotations
+
+import inspect
 import re
-from collections.abc import Collection, Sequence
+from collections.abc import Collection, Hashable, Mapping, Sequence
 from functools import wraps
-from itertools import count
-from typing import Union
+from typing import Any, Callable, Union
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
-from pykelihood.parameters import Parameter, ParametrizedFunction, ensure_parametrized
+from pykelihood.effects import (
+    BoundEffect,
+    CategoricalEffect,
+    Effect,
+    FunctionEffect,
+    build_effect,
+)
+from pykelihood.effects import categorical as _categorical_effect
+from pykelihood.effects import constant as _constant_effect
+from pykelihood.effects import exp as _exp_effect
+from pykelihood.effects import gaussian as _gaussian_effect
+from pykelihood.effects import linear as _linear_effect
+from pykelihood.expr import Constant, Expr, FunctionExpr, PathElem, require_expr
+from pykelihood.parameters import (
+    ConstantParameter,
+    Parameter,
+    Parametrized,
+    ensure_parametrized,
+)
+from pykelihood.state import initial_state
+
+RegressionData = Union[pd.DataFrame, npt.NDArray[np.float64]]
+KernelArg = Union["Kernel", Effect, Expr, npt.ArrayLike]
 
 
-class Kernel(ParametrizedFunction):
+class _CompatNode(Parametrized):
+    """Represent an expression node through the `Parametrized` interface."""
+
+    def __init__(
+        self,
+        factory: Callable[..., Effect | Expr],
+        *,
+        name: str,
+        params: Mapping[str, Parametrized],
+    ) -> None:
+        self._factory = factory
+        self._name = name
+        self._params_names = tuple(params)
+        self._params = tuple(params.values())
+
+    @property
+    def params_names(self) -> tuple[str, ...]:
+        return self._params_names
+
+    def _build_instance(self, **new_params):
+        merged = dict(self.param_dict)
+        merged.update(
+            {name: _compat_param(value) for name, value in new_params.items()}
+        )
+        return type(self)(self._factory, name=self._name, params=merged)
+
+    def to_node(self) -> Effect | Expr:
+        return self._factory(*(_compat_to_node(param) for param in self._params))
+
+    def __call__(self):
+        expr = require_expr(self.to_node())
+        return expr.eval(initial_state(expr))
+
+
+def _compat_param(value: Any) -> Parametrized:
+    """Normalize a kernel argument to a `Parametrized` child."""
+    if isinstance(value, Kernel):
+        return value._compat
+    if isinstance(value, Parametrized):
+        return value
+    if isinstance(value, (Effect, Expr)):
+        return _compat_from_node(value)
+    return ensure_parametrized(value)
+
+
+def _compat_to_node(param: Parametrized) -> Effect | Expr:
+    if isinstance(param, _CompatNode):
+        return param.to_node()
+    return param
+
+
+def _compat_from_node(node: Effect | Expr) -> Parametrized:
+    """Translate an expression tree into a `Parametrized` shape."""
+    if isinstance(node, Parametrized):
+        return node
+    if isinstance(node, Constant):
+        return ConstantParameter(node.value)
+    if isinstance(node, FunctionExpr):
+        names = tuple(
+            str(index if node.arg_names is None else node.arg_names[index])
+            for index, _ in enumerate(node.args)
+        )
+        params = {name: _compat_from_node(arg) for name, arg in zip(names, node.args)}
+        return _CompatNode(
+            lambda *args: FunctionExpr(
+                node.function,
+                tuple(require_expr(arg) for arg in args),
+                node.name,
+                node.arg_names,
+            ),
+            name=node.name,
+            params=params,
+        )
+    if isinstance(node, FunctionEffect):
+        keys = tuple(node.args)
+        params = {str(name): _compat_from_node(arg) for name, arg in node.args.items()}
+        return _CompatNode(
+            lambda *args: FunctionEffect(
+                node.function, dict(zip(keys, args)), node.name
+            ),
+            name=node.name,
+            params=params,
+        )
+    if isinstance(node, CategoricalEffect):
+        used_names: dict[str, int] = {}
+        names_by_level: dict[Hashable, str] = {}
+        for level in node.levels:
+            base_name = str(level)
+            count = used_names.get(base_name, 0)
+            name = base_name if count == 0 else f"{base_name}_{count}"
+            used_names[base_name] = count + 1
+            names_by_level[level] = name
+        params = {
+            names_by_level[level]: _compat_from_node(node.level_args[level])
+            for level in node.levels
+        }
+        return _CompatNode(
+            lambda *args: CategoricalEffect(
+                node.levels, {level: arg for level, arg in zip(node.levels, args)}
+            ),
+            name="categorical",
+            params=params,
+        )
+    raise TypeError(
+        f"Unsupported node type for kernel compatibility: {type(node).__name__}"
+    )
+
+
+class Kernel(Parametrized):
     """
     Represents a kernel function of one covariate with parameters.
-
-    Parameters
-    ----------
-    f : callable
-        The kernel function to be wrapped.
-    x : array-like, optional
-        Covariates on which the kernel will operate.
-    fname : str, optional
-        Name of the kernel function.
-    params : dict
-        Parameters of the kernel function.
     """
 
-    def __init__(self, f, x=None, fname=None, **params):
-        """Function of one covariate with parameters."""
-        fname = fname or f.__qualname__
-        super().__init__(f, fname=fname, **params)
-        self._validate(x)
-        self.x = x
+    def __init__(self, effect: Effect, covariate: npt.ArrayLike | None = None) -> None:
+        self.covariate = covariate
+        self._compat = _compat_from_node(effect)
+        self._params_names = self._compat.params_names
+        self._params = self._compat.params
 
-    def _validate(self, x):
-        """
-        Validates the covariate input.
+    @classmethod
+    def from_compat(
+        cls, compat: Parametrized, covariate: npt.ArrayLike | None = None
+    ) -> Kernel:
+        instance = cls.__new__(cls)
+        instance.covariate = covariate
+        instance._compat = compat
+        instance._params_names = compat.params_names
+        instance._params = compat.params
+        return instance
 
-        Parameters
-        ----------
-        x : array-like
-            Covariates to validate.
+    @property
+    def params_names(self) -> tuple[str, ...]:
+        return self._params_names
 
-        Raises
-        ------
-        ValueError
-            If `x` is not iterable.
-        """
-        try:
-            iter(x)
-        except TypeError:
-            raise ValueError(
-                f"Incorrect covariate for {self.fname}: {self.x}"
-            ) from None
+    @property
+    def effect(self) -> Effect:
+        return _compat_to_node(self._compat)  # pyright: ignore[reportReturnType]
 
     def __call__(self, x=None):
         """
@@ -61,21 +180,21 @@ class Kernel(ParametrizedFunction):
         Parameters
         ----------
         x : array-like, optional
-            Covariate values. If not provided, uses the instance's `x`.
+            Covariate values. If not provided, uses the instance's `covariate`.
 
         Returns
         -------
         float
             Result of the kernel function evaluation.
         """
-        if x is None:
-            x = self.x
-        self._validate(x)
-        param_values = {p_name: p() for p_name, p in self.param_dict.items()}
-        return self.f(x, **param_values)
+        covariate = self.covariate if x is None else x
+        if covariate is None:
+            covariate = np.array(0.0, dtype=np.float64)
+        return BoundEffect(self.effect, covariate).eval({})
 
     def _build_instance(self, **new_params):
-        return type(self)(self.f, self.x, fname=self.fname, **new_params)
+        compat = self._compat._build_instance(**new_params)
+        return type(self).from_compat(compat, self.covariate)
 
     def with_covariate(self, covariate):
         """
@@ -91,10 +210,49 @@ class Kernel(ParametrizedFunction):
         Kernel
             New kernel instance with updated covariate.
         """
-        return type(self)(self.f, covariate, fname=self.fname, **self.param_dict)
+        return type(self).from_compat(self._compat, covariate)
 
 
-class constant(Kernel):
+def _unwrap_kernel_arg(value: KernelArg) -> Effect | Expr | npt.ArrayLike:
+    if isinstance(value, Kernel):
+        return value.effect
+    return value
+
+
+def _kernel_arguments(
+    **kwargs: KernelArg | None,
+) -> dict[PathElem, Effect | Expr | npt.ArrayLike]:
+    return {
+        name: _unwrap_kernel_arg(value)
+        for name, value in kwargs.items()
+        if value is not None
+    }
+
+
+def kernel(function: Callable[..., Any]) -> Callable[..., Kernel]:
+    signature = inspect.signature(function)
+    parameters = tuple(signature.parameters.values())
+    if not parameters:
+        raise TypeError("kernel expects a function with a covariate parameter.")
+    kernel_parameters = parameters[1:]
+    kernel_signature = inspect.Signature(parameters=kernel_parameters)
+    parameter_names = tuple(parameter.name for parameter in kernel_parameters)
+
+    @wraps(function)
+    def build(x: npt.ArrayLike | None = None, *args: Any, **kwargs: Any) -> Kernel:
+        bound = kernel_signature.bind_partial(*args, **kwargs)
+        effect = build_effect(
+            function,
+            name=function.__name__,
+            parameter_names=parameter_names,
+            arguments=_kernel_arguments(**bound.arguments),
+        )
+        return Kernel(effect, x)
+
+    return build
+
+
+def constant(value: KernelArg = 0.0) -> Kernel:
     """
     A kernel representing a constant value.
 
@@ -103,93 +261,30 @@ class constant(Kernel):
     value : float, optional
         Constant value for the kernel. Default is 0.0.
     """
-
-    def __init__(self, value=0.0):
-        super().__init__(self._call, fname="constant", value=value)
-
-    def _build_instance(self, value):
-        return constant(value)
-
-    def _validate(self, x):
-        """
-        Validates the input for the constant kernel.
-
-        Parameters
-        ----------
-        x : any
-            Input value to validate.
-
-        Raises
-        ------
-        ValueError
-            If `x` is not None.
-        """
-        if x is not None:
-            raise ValueError(f"Unexpected data for constant kernel: {x}")
-
-    def _call(self, _x, value):
-        """
-        Compute the constant kernel value.
-
-        Parameters
-        ----------
-        _x : any
-            Ignored input.
-        value : float
-            The constant value.
-
-        Returns
-        -------
-        float
-            The constant value.
-        """
-        return value
+    unwrapped = _unwrap_kernel_arg(value)
+    if isinstance(unwrapped, (Effect, Expr)):
+        effect = _constant_effect(unwrapped)
+    else:
+        effect = _constant_effect(Parameter(unwrapped))
+    return Kernel(effect, None)
 
 
-def kernel(**param_defaults):
-    """
-    Decorator for creating a kernel function with parameters.
-
-    Parameters
-    ----------
-    param_defaults : dict
-        Default values for the kernel parameters.
-
-    Returns
-    -------
-    callable
-        A decorated kernel function.
-    """
-
-    def wrapper(f):
-        @wraps(f)
-        def wrapped(x, **param_values) -> Kernel:
-            final_params = {}
-            for p_name, default_value in param_defaults.items():
-                override = param_values.get(p_name)
-                if override is not None:
-                    final_params[p_name] = ensure_parametrized(override, constant=True)
-                else:
-                    final_params[p_name] = ensure_parametrized(default_value)
-            return Kernel(f, x, fname=f.__name__, **final_params)
-
-        return wrapped
-
-    return wrapper
-
-
-@kernel(a=0.0, b=0.0)
-def linear(X, a, b):
+def linear(
+    x: npt.ArrayLike | None = None,
+    *,
+    a: KernelArg | None = None,
+    b: KernelArg | None = None,
+) -> Kernel:
     r"""
     Linear kernel function.
 
     .. math::
 
-        y = a + b \cdot X
+        y = a + b \cdot x
 
     Parameters
     ----------
-    X : array-like
+    x : array-like
         Input data.
     a : float
         Intercept of the linear function.
@@ -201,11 +296,48 @@ def linear(X, a, b):
     array-like
         Output of the linear kernel.
     """
-    return a + b * X
+    effect_kwargs = {}
+    if b is not None:
+        effect_kwargs["slope"] = _unwrap_kernel_arg(b)
+
+    effect: Effect = _linear_effect(**effect_kwargs)
+    if not isinstance(effect, FunctionEffect):
+        raise TypeError("effects.linear is expected to return a FunctionEffect.")
+    linear_effect = effect
+    if a is not None:
+        effect = build_effect(
+            lambda x, a, b: a + b * x,
+            name="linear",
+            parameter_names=("a", "b"),
+            arguments={"a": _unwrap_kernel_arg(a), "b": linear_effect.args["slope"]},
+        )
+    elif x is None:
+        effect = build_effect(
+            lambda x, a, b: a + b * x,
+            name="linear",
+            parameter_names=("a", "b"),
+            arguments={
+                "a": Parameter(init=0.0, name="a"),
+                "b": Parameter(init=0.0, name="b"),
+            },
+        )
+    else:
+        effect = build_effect(
+            lambda x, a, b: a + b * x,
+            name="linear",
+            parameter_names=("a", "b"),
+            arguments={
+                "a": Parameter(init=0.0, name="a"),
+                "b": linear_effect.args["slope"],
+            },
+        )
+    return Kernel(effect, x)
 
 
-@kernel(a=0.0, b=0.0, c=0.0)
-def polynomial(X, a, b, c):
+@kernel
+def polynomial(
+    x: npt.ArrayLike, a: Any = None, b: Any = None, c: Any = None
+) -> npt.NDArray[np.float64]:
     r"""
     Polynomial kernel function.
 
@@ -229,11 +361,14 @@ def polynomial(X, a, b, c):
     array-like
         Output of the polynomial kernel.
     """
-    return a + b * X + c * X**2
+    x_value = np.asarray(x, dtype=np.float64)
+    return a + b * x_value + c * x_value**2
 
 
-@kernel(a=0.0, b=0.0)
-def exponential(X, a, b):
+@kernel
+def exponential(
+    x: npt.ArrayLike, a: Any = None, b: Any = None
+) -> npt.NDArray[np.float64]:
     r"""
     Exponential kernel function.
 
@@ -255,13 +390,13 @@ def exponential(X, a, b):
     array-like
         Exponential of the linear function.
     """
-    inner = b * X
-    inner = a + inner
-    return np.exp(inner)
+    return np.exp(a + b * x)
 
 
-@kernel(a=0.0, b=1.0, c=1.0)
-def exponential_ratio(X, a, b, c):
+@kernel
+def exponential_ratio(
+    x: npt.ArrayLike, a: Any = None, b: Any = None, c: Any = None
+) -> npt.NDArray[np.float64]:
     r"""
     Exponential ratio kernel function.
 
@@ -285,11 +420,16 @@ def exponential_ratio(X, a, b, c):
     array-like
         Exponential ratio kernel output.
     """
-    return c * np.exp(a * X / b)
+    return c * np.exp(a * x / b)
 
 
-@kernel(mu=0.0, sigma=1.0, scaling=1.0)
-def gaussian(X, mu, sigma, scaling):
+def gaussian(
+    x: npt.ArrayLike | None = None,
+    *,
+    mu: KernelArg | None = None,
+    sigma: KernelArg | None = None,
+    scaling: KernelArg | None = None,
+) -> Kernel:
     r"""
     Gaussian kernel function.
 
@@ -314,13 +454,19 @@ def gaussian(X, mu, sigma, scaling):
     array-like
         Gaussian kernel output.
     """
-    mult = scaling * 1 / (sigma * np.sqrt(2 * np.pi))
-    expo = np.exp(-((X - mu) ** 2) / sigma**2)
-    return mult * expo
+    effect_kwargs = {
+        name: _unwrap_kernel_arg(value)
+        for name, value in {"mu": mu, "sigma": sigma, "scaling": scaling}.items()
+        if value is not None
+    }
+    effect = _gaussian_effect(**effect_kwargs)
+    return Kernel(effect, x)
 
 
-@kernel(a=0.0, b=0.0, c=0.0)
-def trigonometric(X, a, b, c):
+@kernel
+def trigonometric(
+    x: npt.ArrayLike, a: Any = None, b: Any = None, c: Any = None
+) -> npt.NDArray[np.float64]:
     r"""
     Trigonometric kernel function.
 
@@ -344,11 +490,14 @@ def trigonometric(X, a, b, c):
     array-like
         Trigonometric kernel output.
     """
-    return a + b * np.cos(2 * np.pi * X) + c * np.sin(2 * np.pi * X)
+    x_value = np.asarray(x, dtype=np.float64)
+    return a + b * np.cos(2 * np.pi * x_value) + c * np.sin(2 * np.pi * x_value)
 
 
-@kernel(mu=0.0, alpha=0.0, theta=1.0)
-def hawkes(X, mu, alpha, theta):
+@kernel
+def hawkes(
+    x: npt.NDArray, mu: Any = None, alpha: Any = None, theta: Any = None
+) -> npt.NDArray[np.float64]:
     r"""
     Hawkes process with exponential kernel.
 
@@ -373,17 +522,12 @@ def hawkes(X, mu, alpha, theta):
         Intensity function values at each time point.
     """
     return mu + alpha * theta * np.array(
-        [np.sum(np.exp(-theta * (X[i] - X[:i]))) for i in range(len(X))]
+        [np.sum(np.exp(-theta * (x[i] - x[:i]))) for i in range(len(x))]
     )
 
 
-"""
-Sophisticated kernels with multiple covariates
-"""
-
-
 def linear_regression(
-    x: Union[pd.DataFrame, np.ndarray], add_intercept=False, **constraints
+    x: RegressionData, add_intercept: bool = False, **constraints: KernelArg
 ) -> Kernel:
     r"""
     Linear regression of the columns in the data.
@@ -411,41 +555,61 @@ def linear_regression(
     float
         The linear sum computed from the input data.
     """
-    if len(x.shape) > 1:
-        ndim = x.shape[1]
-    else:
-        raise ValueError("Consider using kernels.linear for a 1-dimensional data array")
-    fixed = {}
-    for p_name, p_value in constraints.items():
-        if p_name.startswith("beta_"):
-            p_name = p_name[len("beta_") :]
-        if isinstance(x, pd.DataFrame) and p_name in x.columns:
-            index = tuple(x.columns).index(p_name) + 1
+    matrix = np.asarray(x, dtype=np.float64)
+    if matrix.ndim == 1:
+        matrix = matrix[:, np.newaxis]
+    elif matrix.ndim != 2:
+        raise ValueError("linear_regression expects a 1- or 2-dimensional array.")
+    translated_constraints = {}
+    for parameter_name, value in constraints.items():
+        raw_name = parameter_name.removeprefix("beta_")
+        if isinstance(x, pd.DataFrame) and raw_name in x.columns:
+            index = x.columns.get_loc(raw_name)
+            if not isinstance(index, int):
+                raise ValueError(
+                    f"Unable to resolve parameter constraint: {parameter_name}"
+                )
+            translated_name = f"beta_{index + 1}"
         else:
-            index = int(p_name)
-        fixed[index] = ensure_parametrized(p_value, constant=True)
+            translated_name = parameter_name
+        translated_constraints[translated_name] = _unwrap_kernel_arg(value)
 
-    if 0 in fixed and not add_intercept:
+    if "beta_0" in translated_constraints and not add_intercept:
         raise ValueError(
             "A fixed value is given for the intercept, but `add_intercept` is not True."
         )
 
-    param_indices = range(0 if add_intercept else 1, ndim + 1)
-    params = {
-        f"beta_{i}": Parameter(0.0) if i not in fixed else fixed[i]
-        for i in param_indices
-    }
+    parameter_names = tuple(
+        f"beta_{index}"
+        for index in range(0 if add_intercept else 1, matrix.shape[1] + 1)
+    )
 
-    def _compute(data, **params_from_wrapper):
-        intercept = params_from_wrapper.pop("beta_0", 0)
-        sorted_params = [params_from_wrapper[k] for k in params if k != "beta_0"]
-        return intercept + (sorted_params * data).sum(axis=1)
+    def regression_fn(
+        data: npt.ArrayLike, *resolved: npt.ArrayLike
+    ) -> npt.NDArray[np.float64]:
+        data_array = np.asarray(data, dtype=np.float64)
+        if data_array.ndim == 1:
+            data_array = data_array[:, np.newaxis]
+        values = [np.asarray(value, dtype=np.float64) for value in resolved]
+        if add_intercept:
+            intercept, coefficient_values = values[0], values[1:]
+        else:
+            intercept = np.array(0.0, dtype=np.float64)
+            coefficient_values = values
+        coefficients = np.stack(coefficient_values)
+        return intercept + (coefficients * data_array).sum(axis=1)
 
-    return Kernel(_compute, x, **params, fname=linear_regression.__qualname__)
+    effect = build_effect(
+        regression_fn,
+        name="linear_regression",
+        parameter_names=parameter_names,
+        arguments=translated_constraints,
+    )
+    return Kernel(effect, matrix)
 
 
 def exponential_linear_regression(
-    x: Union[pd.DataFrame, np.ndarray], add_intercept=False, **constraints
+    x: RegressionData, add_intercept: bool = False, **constraints: KernelArg
 ) -> Kernel:
     r"""
     Exponential of a linear sum of the columns in the data.
@@ -473,42 +637,12 @@ def exponential_linear_regression(
     float
         The linear sum computed from the input data.
     """
-    if len(x.shape) > 1:
-        ndim = x.shape[1]
-    else:
-        raise ValueError("Consider using kernels.expo for a 1-dimensional data array")
-    fixed = {}
-    for p_name, p_value in constraints.items():
-        if p_name.startswith("beta_"):
-            p_name = p_name[len("beta_") :]
-        if isinstance(x, pd.DataFrame) and p_name in x.columns:
-            index = tuple(x.columns).index(p_name) + 1
-        else:
-            index = int(p_name)
-        fixed[index] = ensure_parametrized(p_value, constant=True)
-
-    if 0 in fixed and not add_intercept:
-        raise ValueError(
-            "A fixed value is given for the intercept, but `add_intercept` is not True."
-        )
-
-    param_indices = range(0 if add_intercept else 1, ndim + 1)
-    params = {
-        f"beta_{i}": Parameter(0.0) if i not in fixed else fixed[i]
-        for i in param_indices
-    }
-
-    def _compute(data, **params_from_wrapper):
-        sorted_params = np.stack([params_from_wrapper[k] for k in params])
-        return np.exp((sorted_params * data).sum(axis=1))
-
-    return Kernel(
-        _compute, x, **params, fname=exponential_linear_regression.__qualname__
-    )
+    regression = linear_regression(x, add_intercept=add_intercept, **constraints)
+    return Kernel(_exp_effect(regression.effect), regression.covariate)
 
 
 def polynomial_regression(
-    x: Union[pd.DataFrame, np.ndarray], degree: Union[int, Sequence] = 2, **constraints
+    x: RegressionData, degree: int | Sequence[int] = 2, **constraints: KernelArg
 ) -> Kernel:
     r"""
     Polynomial regression in the columns of the data.
@@ -535,51 +669,79 @@ def polynomial_regression(
     float
         The polynomial regression computed from the input data.
     """
-    if len(x.shape) > 1:
-        ndim = x.shape[1]
-    else:
-        raise ValueError("Consider using kernels.linear for a 1-dimensional data array")
+    matrix = np.asarray(x, dtype=np.float64)
     if isinstance(degree, int):
-        assert degree > 0, "This model considers positive power laws only."
-        degree = [degree] * ndim
+        effect_degree = int(degree)
+        degrees = [effect_degree] * matrix.shape[1]
     else:
-        assert len(degree) == ndim, (
-            "The number of degrees is different than the number of covariates."
-        )
-    ncols = sum(degree)
-    fixed = {}
-    for p_name, p_value in constraints.items():
-        if p_name.startswith("beta_"):
-            p_name = p_name[len("beta_") :]
-        match = re.match(r"^(.+)_(\d+)$", p_name)
-        if match:
-            column, deg = match.groups()
+        degrees = list(degree)
+        if len(degrees) != matrix.shape[1]:
+            raise ValueError(
+                "The number of degrees is different than the number of covariates."
+            )
+        effect_degree = max(degrees)
+
+    translated_constraints = {}
+    for parameter_name, value in constraints.items():
+        raw_name = parameter_name.removeprefix("beta_")
+        match = re.match(r"^(.+)_(\d+)$", raw_name)
+        if match is None:
+            raise ValueError(f"Unable to parse parameter constraint: {parameter_name}")
+        column_name, power = match.groups()
+        if isinstance(x, pd.DataFrame) and column_name in x.columns:
+            column_index = x.columns.get_loc(column_name)
+            if not isinstance(column_index, int):
+                raise ValueError(
+                    f"Unable to resolve parameter constraint: {parameter_name}"
+                )
+            translated_name = f"beta_{column_index + 1}_{power}"
         else:
-            raise ValueError(f"Unable to parse parameter constraint: {p_name}")
-        if isinstance(x, pd.DataFrame) and column in x.columns:
-            column = list(x.columns).index(column) + 1
-        fixed[(int(column), int(deg))] = ensure_parametrized(p_value, constant=True)
-    params = {}
-    for col_idx, max_degree in enumerate(degree):
-        for d in range(1, max_degree + 1):
-            name = f"beta_{col_idx + 1}_{d}"
-            params[name] = fixed.get((col_idx + 1, d), Parameter(0.0))
+            translated_name = f"beta_{int(column_name)}_{power}"
+        translated_constraints[translated_name] = _unwrap_kernel_arg(value)
 
-    def _compute(data, **params_from_wrapper):
-        data = np.array(data)
-        data_with_extra_cols = np.zeros(shape=(len(data), ncols))
-        extra_col_idx = 0
-        for col_idx, max_degree in enumerate(degree):
-            for d in range(1, max_degree + 1):
-                data_with_extra_cols[:, extra_col_idx] = data[:, col_idx] ** d
-                extra_col_idx += 1
-        sorted_params = [params_from_wrapper[k] for k in params]
-        return (sorted_params * data_with_extra_cols).sum(axis=1)
+    for column_index, max_degree in enumerate(degrees, start=1):
+        for power in range(max_degree + 1, effect_degree + 1):
+            translated_constraints[f"beta_{column_index}_{power}"] = 0.0
 
-    return Kernel(_compute, x, **params, fname=polynomial_regression.__qualname__)
+    parameter_names = tuple(
+        f"beta_{column_index}_{power}"
+        for column_index, max_degree in enumerate(degrees, start=1)
+        for power in range(1, max_degree + 1)
+    )
+
+    filtered_constraints = {
+        name: value
+        for name, value in translated_constraints.items()
+        if name in parameter_names
+    }
+
+    def regression_fn(
+        data: npt.ArrayLike, *resolved: npt.ArrayLike
+    ) -> npt.NDArray[np.float64]:
+        data_array = np.asarray(data, dtype=np.float64)
+        expanded_columns = [
+            data_array[:, column_index] ** power
+            for column_index, max_degree in enumerate(degrees)
+            for power in range(1, max_degree + 1)
+        ]
+        expanded = np.stack(expanded_columns, axis=1)
+        coefficients = np.stack(
+            [np.asarray(value, dtype=np.float64) for value in resolved]
+        )
+        return (coefficients * expanded).sum(axis=1)
+
+    effect = build_effect(
+        regression_fn,
+        name="polynomial_regression",
+        parameter_names=parameter_names,
+        arguments=filtered_constraints,
+    )
+    return Kernel(effect, x)
 
 
-def categories_qualitative(x: Collection, fixed_values: dict = None) -> Kernel:
+def categories_qualitative(
+    x: Collection[Hashable], fixed_values: Mapping[Any, KernelArg] | None = None
+) -> Kernel:
     """
     Kernel for qualitative (categorical) data.
 
@@ -606,19 +768,11 @@ def categories_qualitative(x: Collection, fixed_values: dict = None) -> Kernel:
     >>> data = ['A', 'B', 'A', 'C']
     >>> kernel = categories_qualitative(data, fixed_values={'A': 1.0})
     """
-    unique_values = sorted(set(map(str, x)))
-    fixed_values = {str(k): v for k, v in (fixed_values or {}).items()}
-    parameter = (Parameter(0.0) for _ in count())  # generate parameters on demand
-    params = {
-        value: (
-            next(parameter)
-            if value not in fixed_values
-            else ensure_parametrized(fixed_values[value], constant=True)
-        )
-        for value in unique_values
-    }
-
-    def _compute(data, **params_from_wrapper):
-        return type(data)(list(map(lambda v: params_from_wrapper[str(v)], data)))
-
-    return Kernel(_compute, x, **params, fname=categories_qualitative.__qualname__)
+    levels = tuple(dict.fromkeys(x))
+    effect = _categorical_effect(
+        levels=levels,
+        fixed_values=None
+        if fixed_values is None
+        else {key: _unwrap_kernel_arg(value) for key, value in fixed_values.items()},
+    )
+    return Kernel(effect, x)  # pyright: ignore[reportArgumentType]

--- a/pykelihood/parameters.py
+++ b/pykelihood/parameters.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import abc
 from collections import ChainMap
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import numpy as np
 import numpy.typing as npt
 
-from pykelihood.expr import Node
+from pykelihood.expr import Expr
 from pykelihood.state import Transform
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing_extensions import Self
 
 _T = TypeVar("_T")
 
@@ -39,7 +39,7 @@ def ensure_parametrized(x: Any, constant=False) -> Parametrized:
     return cls(x)
 
 
-class Parametrized(Node, abc.ABC):
+class Parametrized(Expr, abc.ABC):
     """
     Base class for parametrized objects.
     """
@@ -226,6 +226,9 @@ class Parametrized(Node, abc.ABC):
         """
         raise NotImplementedError("A generic Parametrized object has no value!")
 
+    def eval(self, state: Mapping[Parameter, npt.NDArray[np.float64]]):
+        return self()
+
     def __repr__(self):
         args = [f"{a}={v!r}" for a, v in zip(self.params_names, self._params)]
         return f"{type(self).__name__}({', '.join(args)})"
@@ -371,7 +374,7 @@ class Parameter(Parametrized):
         return (self,)
 
     @property
-    def optimisation_params(self):
+    def optimisation_params(self) -> tuple[Parameter, ...]:
         """
         Get the parameter itself for optimization.
 
@@ -382,7 +385,7 @@ class Parameter(Parametrized):
         """
         return (self,)
 
-    def with_params(self, params):
+    def with_params(self, params: Iterable | None = None, **named_params):
         """
         Create a new instance of the parameter with the given value.
 
@@ -396,6 +399,8 @@ class Parameter(Parametrized):
         Parameter
             The new instance.
         """
+        if params is None or named_params:
+            raise ValueError("Parameters only support positional replacement values.")
         param = next(iter(params))
         if isinstance(param, ConstantParameter):
             return param
@@ -426,6 +431,13 @@ class Parameter(Parametrized):
         float
             The value.
         """
+        return self.value
+
+    def eval(
+        self, state: Mapping[Parameter, npt.NDArray[np.float64]]
+    ) -> npt.NDArray[np.float64]:
+        if self in state:
+            return np.asarray(state[self], dtype=np.float64)
         return self.value
 
     def __repr__(self):
@@ -470,7 +482,7 @@ class ConstantParameter(Parameter):
     Utility class used to manage parameters that are not optimized.
     """
 
-    def with_params(self, params):
+    def with_params(self, params: Iterable | None = None, **named_params):
         """
         Return the parameter itself, as it is constant.
 
@@ -487,7 +499,7 @@ class ConstantParameter(Parameter):
         return self
 
     @property
-    def optimisation_params(self):
+    def optimisation_params(self) -> tuple[Parameter, ...]:
         """
         Do not include in optimization parameters.
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from pykelihood.effects import (
+    BoundEffect,
+    CategoricalEffect,
+    Effect,
+    FunctionEffect,
+    build_effect,
+    categorical,
+    constant,
+    exp,
+    gaussian,
+    linear,
+    polynomial,
+)
+from pykelihood.effects import sum as effect_sum
+from pykelihood.expr import Expr
+from pykelihood.parameters import Parameter
+from pykelihood.state import ParameterLayout, initial_state
+
+
+def test_constant_effect_evaluation() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    const_effect = constant(3.0)
+    assert_allclose(const_effect.with_covariate(x).eval({}), np.array([3.0, 3.0, 3.0]))
+
+
+def test_linear_effect_evaluation() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    linear_effect = linear(slope=2.0)
+    assert isinstance(linear_effect, Effect)
+    assert_allclose(linear_effect.with_covariate(x).eval({}), np.array([0.0, 2.0, 4.0]))
+
+
+def test_effect_addition_evaluation() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    affine_effect = constant(1.0) + linear(slope=2.0)
+    assert isinstance(affine_effect, Effect)
+    assert_allclose(affine_effect.with_covariate(x).eval({}), np.array([1.0, 3.0, 5.0]))
+
+
+def test_effect_helpers_create_free_parameters_when_omitted() -> None:
+    linear_effect = linear()
+    const_effect = constant()
+    assert isinstance(linear_effect, FunctionEffect)
+    assert isinstance(const_effect, FunctionEffect)
+
+    assert isinstance(linear_effect.args["slope"], Parameter)
+    assert isinstance(const_effect.args["value"], Parameter)
+    assert linear_effect.args["slope"].init is not None
+    assert const_effect.args["value"].init is not None
+    assert_allclose(linear_effect.args["slope"].init, np.array(0.0))
+    assert_allclose(const_effect.args["value"].init, np.array(0.0))
+
+
+def test_build_effect_creates_free_parameters_for_omitted_arguments() -> None:
+    effect = build_effect(
+        lambda x, offset, slope: offset + slope * x,
+        name="affine",
+        parameter_names=("offset", "slope"),
+        arguments={"offset": 1.0},
+    )
+
+    assert isinstance(effect.args["slope"], Parameter)
+    assert effect.args["slope"].init is not None
+    assert_allclose(effect.args["slope"].init, np.array(0.0))
+
+
+def test_build_effect_uses_fixed_values() -> None:
+    effect = build_effect(
+        lambda x, a, b, c: a + b * x + c * x**2,
+        name="quadratic",
+        parameter_names=("a", "b", "c"),
+        arguments={"a": 1.0, "b": 2.0, "c": 3.0},
+    )
+
+    assert_allclose(
+        effect.with_covariate(np.array([1.0, 2.0])).eval({}), np.array([6.0, 17.0])
+    )
+
+
+def test_build_effect_accepts_symbolic_values() -> None:
+    shift = Parameter(2.0)
+    offset = shift + 1.0
+    effect = build_effect(
+        lambda x, offset, slope: offset + slope * x,
+        name="affine",
+        parameter_names=("offset", "slope"),
+        arguments={"offset": offset, "slope": Parameter(init=3.0, name="slope")},
+    )
+
+    assert_allclose(
+        effect.with_covariate(np.array([0.0, 1.0, 2.0])).eval({}),
+        np.array([3.0, 6.0, 9.0]),
+    )
+
+
+def test_polynomial_effect_uses_degree_and_named_coefficients() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    effect = polynomial(degree=2, init={1: 2.0}, _coefficients={0: 1.0, 2: 3.0})
+    assert isinstance(effect, FunctionEffect)
+
+    assert isinstance(effect.args[1], Parameter)
+    assert_allclose(effect.with_covariate(x).eval({}), 1 + 2.0 * x + 3.0 * x**2)
+
+
+def test_polynomial_effect_supports_vector_coefficients() -> None:
+    effect = polynomial(
+        degree=2,
+        _coefficients={
+            0: np.array([1.0, 10.0]),
+            1: np.array([2.0, 20.0]),
+            2: np.array([3.0, 30.0]),
+        },
+    )
+
+    assert_allclose(
+        effect.with_covariate(np.array(2.0)).eval({}), np.array([17.0, 170.0])
+    )
+
+
+def test_effects_can_be_composed_with_math_and_reductions() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    base = polynomial(degree=2, _coefficients={0: 1.0, 1: 2.0, 2: 3.0})
+    composed = exp(base)
+    reduced = effect_sum(base)
+
+    base_value = 1 + 2.0 * x + 3.0 * x**2
+    assert_allclose(composed.with_covariate(x).eval({}), np.exp(base_value))
+    assert_allclose(reduced.with_covariate(x).eval({}), np.sum(base_value))
+
+
+def test_effects_can_mix_with_exprs() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    shift = Parameter(init=1.5)
+    mixed = polynomial(degree=1, _coefficients={0: 1.0, 1: 2.0}) + shift
+
+    assert_allclose(
+        mixed.with_covariate(x).eval({shift: np.array(1.5)}), np.array([2.5, 4.5, 6.5])
+    )
+
+
+def test_effect_evaluation_accepts_full_explicit_state() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    c = Parameter()
+    slope = Parameter()
+    effect = constant(c) + linear(slope)
+    bound = effect.with_covariate(x)
+    state = {c: np.array(1.0), slope: np.array(2.0)}
+
+    assert_allclose(bound.eval(state), np.array([1.0, 3.0, 5.0]))
+
+
+def test_effect_evaluation_uses_explicitly_merged_initial_state() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    slope = Parameter(5.0)
+    effect = constant(1.0) + linear(slope=slope)
+    bound = effect.with_covariate(x)
+    state = initial_state(bound) | {slope: np.array(2.0)}
+
+    assert_allclose(bound.eval(state), np.array([1.0, 3.0, 5.0]))
+
+
+def test_effect_composition_uses_nested_bound_covariate_over_outer_one() -> None:
+    inner_x = np.array([0.0, 1.0, 2.0])
+    outer_x = np.array([10.0, 20.0, 30.0])
+    slope = Parameter()
+    nested = linear(slope=slope).with_covariate(inner_x)
+    effect = constant(1.0) + nested
+
+    expected = np.array([1.0, 3.0, 5.0])
+    assert_allclose(
+        effect.with_covariate(outer_x).eval({slope: np.array(2.0)}), expected
+    )
+    assert_allclose(effect.eval(outer_x, {slope: np.array(2.0)}), expected)
+
+
+def test_gaussian_effect_is_available_as_reference_builtin() -> None:
+    x = np.array([0.0, 1.0])
+    effect = gaussian(mu=0.0, sigma=1.0, scaling=1.0)
+
+    assert_allclose(
+        effect.with_covariate(x).eval({}),
+        np.array([1.0 / np.sqrt(2.0 * np.pi), np.exp(-1.0) / np.sqrt(2.0 * np.pi)]),
+    )
+
+
+def test_bound_linear_effect_discovers_slope_parameter() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    slope = Parameter(2.0)
+    effect = linear(slope=slope).with_covariate(x)
+    layout = ParameterLayout.from_expr(effect)
+
+    assert isinstance(effect, BoundEffect)
+    assert layout.parameters == (slope,)
+    assert layout.parameter_paths[slope] == (("slope",),)
+
+
+def test_effect_layout_tracks_all_paths_for_shared_parameter() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    shared = Parameter(2.0)
+    effect = (constant(shared) + linear(slope=shared)).with_covariate(x)
+    layout = ParameterLayout.from_expr(effect)
+
+    assert layout.parameters == (shared,)
+    assert layout.parameter_paths[shared] == (("left", "value"), ("right", "slope"))
+    assert_allclose(effect.eval({shared: np.array(3.0)}), np.array([3.0, 6.0, 9.0]))
+
+
+def test_exponential_effect_is_expressed_with_exp_and_linear() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    effect = exp(constant(1.0) + linear(slope=2.0))
+
+    assert_allclose(
+        effect.with_covariate(x).eval({}), np.exp(np.array([1.0, 3.0, 5.0]))
+    )
+
+
+def test_linear_intercept_is_expressed_with_arithmetic() -> None:
+    x = np.array([0.0, 1.0, 2.0])
+    effect = constant(1.0) + linear(slope=2.0)
+
+    assert_allclose(effect.with_covariate(x).eval({}), np.array([1.0, 3.0, 5.0]))
+
+
+def test_categorical_uses_original_levels_for_matching() -> None:
+    levels = [1, "1"]
+    covariate = np.asarray([1, "1", 1, "1"], dtype=object)
+    effect = categorical(levels=levels, fixed_values={1: 2.0, "1": 3.0})
+
+    assert tuple(effect.level_args) == (1, "1")
+    level_one = effect.level_args[1]
+    level_string_one = effect.level_args["1"]
+    assert isinstance(level_one, Expr)
+    assert isinstance(level_string_one, Expr)
+    assert_allclose(level_one.eval({}), np.array(2.0))
+    assert_allclose(level_string_one.eval({}), np.array(3.0))
+    assert_allclose(
+        effect.with_covariate(covariate).eval({}), np.array([2.0, 3.0, 2.0, 3.0])
+    )
+
+
+def test_categorical_accepts_enum_levels() -> None:
+    class Category(Enum):
+        FIRST = auto()
+        SECOND = auto()
+
+    levels = [Category.FIRST, None, Category.SECOND]
+    covariate = np.asarray(levels, dtype=object)
+    effect = categorical(
+        levels=levels, fixed_values={Category.FIRST: 2.0, Category.SECOND: 3.0}
+    )
+    assert isinstance(effect, CategoricalEffect)
+    assert tuple(effect.level_args) == (Category.FIRST, None, Category.SECOND)
+    none_level = effect.level_args[None]
+    assert isinstance(none_level, Parameter)
+    bound = effect.with_covariate(covariate)
+
+    assert_allclose(
+        bound.eval(initial_state(bound) | {none_level: np.array(4.0)}),
+        np.array([2.0, 4.0, 3.0]),
+    )
+
+
+def test_categorical_rejects_duplicate_levels() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        categorical(levels=[1, 2, 1])

--- a/tests/test_foundations.py
+++ b/tests/test_foundations.py
@@ -2,9 +2,17 @@ from typing import Union
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from pykelihood import parameters
-from pykelihood.expr import Constant, FunctionExpr, Node, PathElem, ensure_node
+from pykelihood.expr import (
+    Constant,
+    FunctionExpr,
+    Node,
+    PathElem,
+    ensure_node,
+    require_expr,
+)
 
 
 class BareParametrized(parameters.Parametrized):
@@ -46,7 +54,7 @@ def test_arithmetic_operators_evaluate_as_expected(builder, expected) -> None:
     expr = builder(param)
 
     assert isinstance(expr, FunctionExpr)
-    np.testing.assert_allclose(expr(), expected)
+    assert_allclose(expr.eval({}), expected)
 
 
 def test_parameter_traversal_is_deterministic() -> None:
@@ -67,29 +75,42 @@ def test_literal_values_normalize_into_constant_nodes() -> None:
     children = list(expr.iter_children())
 
     assert isinstance(children[1][1], Constant)
-    np.testing.assert_allclose(children[1][1](), 3.0)
-    assert children[1][1]().dtype == np.float64
+    assert_allclose(children[1][1].eval({}), 3.0)
+    assert children[1][1].eval({}).dtype == np.float64
 
 
 def test_ensure_node_is_idempotent_for_nodes() -> None:
-    parameter = parameters.Parameter(2.0)
+    node = Node()
+    assert ensure_node(node) is node
 
+
+def test_ensure_node_is_idempotent_for_exprs() -> None:
+    parameter = parameters.Parameter(2.0)
     assert ensure_node(parameter) is parameter
 
 
 def test_ensure_node_wraps_literals_as_float64_constants() -> None:
     constant = ensure_node([1, 2, 3])
-
     assert isinstance(constant, Constant)
-    np.testing.assert_allclose(constant(), np.array([1.0, 2.0, 3.0]))
+    assert_allclose(constant.eval({}), np.array([1.0, 2.0, 3.0]))
     assert constant.value.dtype == np.float64
+
+
+def test_require_expr_is_idempotent_for_exprs() -> None:
+    parameter = parameters.Parameter(2.0)
+    assert require_expr(parameter) is parameter
+
+
+def test_require_expr_rejects_non_evaluable_nodes() -> None:
+    with pytest.raises(TypeError, match="Expected an Expr"):
+        require_expr(Node())
 
 
 def test_nested_arithmetic_expressions_evaluate() -> None:
     expr = (parameters.Parameter(2.0) + 1.5) * 4.0 - 3.0
 
     assert isinstance(expr, FunctionExpr)
-    np.testing.assert_allclose(expr(), 11.0)
+    assert_allclose(expr.eval({}), 11.0)
 
 
 def test_binary_expression_children_use_left_and_right_names() -> None:

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -34,6 +34,13 @@ def test_linear_trend_with_constraint(dataset):
     assert (trend.with_params([3])() == 2 + dataset * 3).all()
 
 
+def test_polynomial_trend(dataset):
+    trend = kernels.polynomial(dataset)
+    assert len(trend.params) == 3
+    assert len(trend.optimisation_params) == 3
+    assert (trend.with_params([1, 2, 3])() == 1 + 2 * dataset + 3 * dataset**2).all()
+
+
 def test_trend_in_trend(dataset):
     inner_trend = kernels.linear(dataset)
     outer_trend = kernels.linear(dataset, b=inner_trend)


### PR DESCRIPTION
This PR introduces a new `pykelihood.effects` module that generalizes the kernels. It allows more flexibility to model arbitrary shapes through arithmetic and clearly separated covariate/parameter-binding phases.

The `pykelihood.kernels` module was rewritten to delegate evaluation to the new effects, but maintains backward compatible syntax. It is deprecated in the sense that new effects should be built directly with the new structure, not the hacky kernels approach.

## Underlying ideas

0. A `Node` is any object that can live in `pykelihood`'s computation graph.
1. An `Expr` is a `Node` whose value depends on one or more `Parameter`s. The `Parametrized` class is now a simple wrapper around `Expr` to provide the old interface.
2. An `Effect` is an `Expr` whose value also depends on a covariate. `Kernel`s are wrappers around `Effect`s to provide the old interface. The `Effect` arithmetic mirrors the `Expr` arithmetic, with the addition of an underlying covariate.